### PR TITLE
Expose redis client in the service

### DIFF
--- a/source/middleware/security.js
+++ b/source/middleware/security.js
@@ -324,6 +324,7 @@ module.exports = {
 
 				delete _settings.redis;
 				_settings.store = new RedisStore({ client : _redisClient });
+				_self.service.redis = _redisClient;
 				_self.service.express.use(session(_settings));
 			} else {
 				_self.service.express.use(session(_settings));


### PR DESCRIPTION
Now you can access the redisClient over `service.redis`